### PR TITLE
Fix for sites using HTTPS

### DIFF
--- a/angular-mailchimp.js
+++ b/angular-mailchimp.js
@@ -21,7 +21,7 @@ angular.module('mailchimp', ['ng', 'ngResource', 'ngSanitize'])
           url;
 
       // Create a resource for interacting with the MailChimp API
-      url = 'http://' + mailchimp.username + '.' + mailchimp.dc + '.list-manage.com/subscribe/post-json';
+      url = '//' + mailchimp.username + '.' + mailchimp.dc + '.list-manage.com/subscribe/post-json';
       params = {
         'EMAIL': mailchimp.email,
         'FNAME': mailchimp.fname,


### PR DESCRIPTION
Use :// instead of http so sites on HTTPS dont error out on chrome

[blocked] The page at 'https...' was loaded over HTTPS, but ran insecure content from 'http://xxx.list-manage.com/subscribe/post-json': this content should also be loaded over HTTPS.
